### PR TITLE
Improving Markdowns based on BryanSmith feedback

### DIFF
--- a/00_intro.py
+++ b/00_intro.py
@@ -8,7 +8,7 @@
 # MAGIC Many companies offer their clients incentives to close deals, renew subscriptions, or purchase services.  These incentives carry costs that may not be recovered if it does not have the expected effect on the client.  In other words, the lack of a data driven incentive allocation policy would most probably result in a sub-optimal or even negative marginal profit.
 # MAGIC
 # MAGIC
-# MAGIC In this solution accelerator we will show how Causal ML (in particular packages in the PyWhy project) can be leveraged in Databricks to facilitate the development of an Incentive Recommender ML Model. This Recommender selects for each customer the incentive(s) that maximized profit, allowing you to get the biggest bang for your incentive bucks! 
+# MAGIC In this solution accelerator we will show how Causal ML (in particular packages in the PyWhy project) can be leveraged in Databricks to facilitate the development of an Incentive Recommender ML Model. This Recommender can be leverage during new account on-boardings to select the incentive(s) that maximized profit from the new client. 
 # MAGIC
 # MAGIC
 # MAGIC ##Why Causal ML?
@@ -84,10 +84,12 @@
 
 # COMMAND ----------
 
+# DBTITLE 1,Loading helper functions
 # MAGIC %run ./util/notebook-config
 
 # COMMAND ----------
 
+# DBTITLE 1,Obtaining summary statistics of the dataset
 # Adjust the types of the input_df for exploratory analysis in the rest of the notebook
 input_df = input_df.astype(normal_type_map)
 
@@ -97,12 +99,33 @@ dbutils.data.summarize(input_df.astype(summarize_type_map), precise=True)
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC The data profile gives us a lot of information. From it we can see we have 5 numerical columns including our target revenue, with the rest as binary categorical columns. We can also see that there is no missing data, and see which categoricals are balanced vs not. The distribution of our numerical columns is also visible at a glance, along with the summary statistics. Finally, there are exactly 10k rows and no missing values. All in all, its pretty easy to observe that this appears to be a very clean synthetic dataset, which is of course the case.
+# MAGIC The data profile gives us a lot of information. From it we can see we have 5 numerical columns including our target revenue:
+# MAGIC - IT Spend
+# MAGIC - Employee Count
+# MAGIC - PC Count
+# MAGIC - Size
+# MAGIC - Revenue
 # MAGIC
-# MAGIC We can also check the impact of each individual treatment on revenue to see which has an impact at the top level.
+# MAGIC The rest of the columns are binary categorical columns, including the three incentives:
+# MAGIC - Global Flag
+# MAGIC - Major Flag
+# MAGIC - SMC Flag
+# MAGIC - Commercial Flag
+# MAGIC - Planning Summit
+# MAGIC - New Product Adoption
+# MAGIC
+# MAGIC Incentives:
+# MAGIC - Tech Support
+# MAGIC - Discount
+# MAGIC - New Engagement Strategy 
+# MAGIC  
+# MAGIC  We can also see that there is no missing data, and see which categoricals are balanced vs not. The distribution of our numerical columns is also visible at a glance, along with the summary statistics. Finally, there are exactly 10k rows. All in all, its pretty easy to observe that this appears to be a very clean synthetic dataset, which is of course the case.
+# MAGIC
+# MAGIC We can also check the impact of each individual incentive on revenue to see which has an impact at the top level.
 
 # COMMAND ----------
 
+# DBTITLE 1,Display a box plot of each incentive vs Revenue (1 = incentive was provided)
 # MAGIC %matplotlib inline
 # MAGIC fig, ax = plt.subplots(1, len(treatment_cols), figsize=(12, 4), sharey=True)
 # MAGIC for i in range(len(treatment_cols)):
@@ -117,6 +140,7 @@ dbutils.data.summarize(input_df.astype(summarize_type_map), precise=True)
 
 # COMMAND ----------
 
+# DBTITLE 1,Checking correlations among the distributions of the numerical features
 sns.pairplot(input_df);
 
 # COMMAND ----------
@@ -128,6 +152,7 @@ sns.pairplot(input_df);
 
 # COMMAND ----------
 
+# DBTITLE 1,Displaying box plots for numerical features vs Revenue
 fig, ax = plt.subplots(len(numerical_cols), len(treatment_cols), figsize=(12, 15), sharey="row")
 for i in range(len(numerical_cols)):
     for j in range(len(treatment_cols)):
@@ -148,6 +173,7 @@ for i in range(len(numerical_cols)):
 
 # COMMAND ----------
 
+# DBTITLE 1,Displaying customer "PC count" vs "Size" vs Incentive provided 
 # Plot the current policy of each customer
 plt.figure(figsize=(10, 7.5))
 plot_policy(input_df, input_df.apply(assign_treatment_label, axis=1))
@@ -155,9 +181,9 @@ plot_policy(input_df, input_df.apply(assign_treatment_label, axis=1))
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC The scatter plot shows that there seems to be no clear guidance on which customer to receive which treatment. Indeed, this simulation assumes no allocation policy, which results in allocation depending solely on the sales teams' decisions and are not consistent. Most probably, this lead to a sub-optimal return.
+# MAGIC The scatter plot displays the account ``pc count`` vs account ``size`` vs ``incentive provided``.  It shows no clear policy was used when assigning an incentive. Indeed, this simulation assumes no allocation policy, which results in allocation depending solely on inconsistant sales teams' decisions. Most probably, this lead to a sub-optimal return.
 # MAGIC
-# MAGIC Now that we have a more intuitive feel for the data and have done some initial analysis and confirmed the quality of our synthetic dataset, lets continue with the demonstration and go beyond correlations to see if we can infer causation among these attributes. In particular, we'll see how to both identify causal relationships and confounders as well as estimate the effects, and then use that information to recommend a personalized incentive structure based on what we know about the accounts. At the end, we'll also demonstrate advanced techniques to ensure we're unable to refute our developed estimators.
+# MAGIC <b>The next notebooks develop an ``Personalized Incentive Recommender`` model to infers the optimal allocation policy based on Causal ML</b>
 
 # COMMAND ----------
 

--- a/02_identification_estimation.py
+++ b/02_identification_estimation.py
@@ -20,7 +20,7 @@ graph = load_graph_from_latest_mlflow_run(experiment_name)
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC We will now identify the total effect of ```Tech Support``` in ```Revenue``` using [DoWhy](https://github.com/py-why/dowhy) to obtain the <b>Average Treatement Effect (ATE)</b> estimand.
+# MAGIC We will now identify the total effect of ```Tech Support``` in ```Revenue``` using [DoWhy](https://github.com/py-why/dowhy) to obtain the <b>[Average Treatement Effect (ATE)](https://en.wikipedia.org/wiki/Average_treatment_effect)</b> estimand. In other words,  we will isolate the average influence ``Tech Support`` had over the ``Revenue`` of accounts.
 
 # COMMAND ----------
 
@@ -50,7 +50,7 @@ print(tech_support_total_effect_identified_estimand)
 # MAGIC %md
 # MAGIC ###Estimating "Tech Support" total effect on "Revenue"
 # MAGIC
-# MAGIC In order to obtain an unbias estimation we will use an approach call [Double Machine Learning (DML)](https://academic.oup.com/ectj/article/21/1/C1/5056401)  which is implemented in the [PyWhy](https://github.com/py-why) package [EconML](https://github.com/py-why/EconML). We use a logistic regression model for predicting the treatment and lasso for predicting the outcome.
+# MAGIC In order to obtain an unbias estimation we will use an approach call [Double Machine Learning (DML)](https://academic.oup.com/ectj/article/21/1/C1/5056401)  which is implemented in the [PyWhy](https://github.com/py-why) package [EconML](https://github.com/py-why/EconML). We use a [logistic regression](https://en.wikipedia.org/wiki/Logistic_regression) model for estimating if the incentive was given and a [lasso regression](https://en.wikipedia.org/wiki/Lasso_(statistics) model for estimating the ``Revenue`` of the account.
 
 # COMMAND ----------
 
@@ -284,6 +284,15 @@ estimates_df = pd.DataFrame(
 )
 
 compare_estimations_vs_ground_truth(ground_truth_df, estimates_df)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC As we can see, the estimations of the models are not only directioanlly correct but very closed the the actual values used in the simulations:
+# MAGIC - ``Tech Support`` direct influence is only off by around $12 
+# MAGIC - ``Tech Support`` accounting for the direct and indirect influences is only off by around $110
+# MAGIC - ``Discount`` direct influence is only off by $4
+# MAGIC - ``New Strategy`` has no influence in ``Revenue``
 
 # COMMAND ----------
 

--- a/03_incentive_recommender.py
+++ b/03_incentive_recommender.py
@@ -34,7 +34,7 @@ class PersonalizedIncentiveRecommender(mlflow.pyfunc.PythonModel):
         effects_interaction = (
             " and ".join(self.models_dictionary.keys()) + " net effect"
         )
-        estimated_effects[effects_interaction] = estimated_effects.sum(axis=1)
+        estimated_effects[effects_interaction] = estimated_effects.sum(axis=1, numeric_only=True)
         return estimated_effects
 
     def _cost_fn_interaction(self, data):
@@ -53,7 +53,7 @@ class PersonalizedIncentiveRecommender(mlflow.pyfunc.PythonModel):
         net_effects["recommended incentive"] = net_effects.idxmax(axis=1).apply(
             lambda x: x.replace(" net effect", "")
         )
-        net_effects["recommended incentive net effect"] = net_effects.max(axis=1)
+        net_effects["recommended incentive net effect"] = net_effects.max(axis=1, numeric_only=True)
         return net_effects
 
     def predict(self, context, model_input):
@@ -170,6 +170,35 @@ compare_policies_effects(final_df)
 
 # MAGIC %md
 # MAGIC This modeling technique (DML) lets us estimate the isolated effect of a given incentive while controlling for confounders. We can obtain an unbiased estimate for each treatment, which is something hard to achieve using traditional ML techniques.
+# MAGIC
+# MAGIC The recommender can be used to obtain the optimal incetive for new accounts given the accounts characteristics.  For example assuming the first of the rows in the "input_df" belong to a new account just onboarded, the sales team can obtain a recommednation of which incentives to offer:
+
+# COMMAND ----------
+
+new_account = input_df.head(1)
+new_account
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ####Obtain Incentives Recommeded for New Account
+
+# COMMAND ----------
+
+incentive_recommended = loaded_model.predict(new_account)
+
+displayHTML(
+    f"<H2>Recommended incentive(s) for new account:</h2><h2>- {incentive_recommended[['recommended incentive']].values[0][0].capitalize()}</H2>"
+)
+
+# COMMAND ----------
+
+incentive_recommended[["recommended incentive"]].values[0][0]
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC MLflow allows leveraging the recommender in [batch processing](https://mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.spark_udf) or as a REST API via [Databricks model serving](https://docs.databricks.com/machine-learning/model-serving/index.html). 
 
 # COMMAND ----------
 


### PR DESCRIPTION
Feedback:
- Could we add a title to teach code block to explain what it is doing for us?
- In 00_Intro, Cmd 6, could we provide a bulletpoint list for each column and an explanation of what each one means?
- For 00_Intro, Cmd 14, could we explain the graph a bit more?  I'm afraid I got really lost looking at this one.
- For 02_Identifiecaiton_Estimation, Cmd 5, could we explain "Average Treatment Effect" a bit more?
- For 02_Identificiation_Estimation, Cmd 8, could we explain "treatment" and "lasso"?
- For 02_Identification_Estimation, Cmd 27, could we explain these numbers a bit more and how we might apply them? Also:
- Added example of recommendation for new account in notebook 03_incentive_recommender.py
- Fixed warning ("Dropping of nuisance columns in DataFrame reductions (with 'numeric_only=None') is deprecated...") on notebook 03_incentive_recommender.py